### PR TITLE
upgrade to sqlite 3.45.3

### DIFF
--- a/build_static_sqlite.sh
+++ b/build_static_sqlite.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-SQLITE_ZIP_URL='https://www.sqlite.org/2021/sqlite-amalgamation-3370000.zip'
+SQLITE_ZIP_URL='https://www.sqlite.org/2024/sqlite-amalgamation-3450300.zip'
 SQLite_compressor='upx'  # Program to use for compressing compiled sqlite
                          # Keep it empty as "" to disable compression
 


### PR DESCRIPTION
Kindly requesting a new release with updated src from sqlite upstream.
- bumps the source to latest `https://www.sqlite.org/2024/sqlite-amalgamation-3450300.zip`, for sqlite 3.45.3

My environment is:

- Ubuntu 24.04 LTS (x86_64)
- Docker 24.0.5
- `alpine:latest` is currently Alpine 3.19.1 (05455a08881e)

```bash
[build2:~/static-sqlite3] $ ./build_static_sqlite.sh
[+] Building 85.2s (10/10) FINISHED                                                                   docker:default
[...]
 => [5/5] RUN  chmod +x /app/Build.sh && ./Build.sh "https://www.sqlite.org/2024/sqlite-amalgamation-3450300.  71.7s
 => exporting to image                                                                                          2.3s
 => => exporting layers                                                                                         2.3s
 => => writing image sha256:4a0a561144111e6925bbcfa221a21e4079c3862dd6622060e2f7569434f00521                    0.0s
 => => naming to docker.io/library/static-sqlite                                                                0.0s

===== Taking ready to use static sqlite3 =======================================

'/app/sqlite-amalgamation-3450300/sqlite3' -> '/release/sqlite3'
Error response from daemon: No such container: static-sqlite
==============================
        not a dynamic executable
------------------------------
sqlite3: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, no section header
------------------------------
SQLite 3.45.3 2024-04-15 13:34:05 8653b758870e6ef0c98d46b3ace27849054af85da891eb121e9aaa537f1e8355
gcc-13.2.1 20231014 (64-bit)
==============================
```

The resulting binary appears to be functional
```bash
[build2:~/static-sqlite3] $ ls -l release/sqlite3; file release/sqlite3; ldd release/sqlite3
-rwxr-xr-x 1 root root 991480 May 16 09:00 release/sqlite3
release/sqlite3: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, no section header
        not a dynamic executable
[build2:~/static-sqlite3] $ ./release/sqlite3 --version
3.45.3 2024-04-15 13:34:05 8653b758870e6ef0c98d46b3ace27849054af85da891eb121e9aaa537f1e8355 (64-bit)
