### PR TITLE
upgrade to sqlite 3.47.0

### DIFF
--- a/build_static_sqlite.sh
+++ b/build_static_sqlite.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-SQLITE_ZIP_URL='https://sqlite.org/2024/sqlite-amalgamation-3460100.zip'
+SQLITE_ZIP_URL='https://sqlite.org/2024/sqlite-amalgamation-3470000.zip'
 SQLite_compressor='upx'  # Program to use for compressing compiled sqlite
                          # Keep it empty as "" to disable compression
 


### PR DESCRIPTION
Bumps the source to latest sqlite 3.47.0

My environment is:
- Ubuntu 24.04.1 LTS (x86_64)
- Docker 24.0.5
- `alpine:latest` is currently Alpine 3.20.3 (63b790fccc90)

Test build:
```bash
build2:~/static-sqlite3$ ./build_static_sqlite.sh
[+] Building 78.4s (10/10) FINISHED                                                                                                                                                                                           docker:default
   [...]
===== Taking ready to use static sqlite3 =======================================

'/app/sqlite-amalgamation-3470000/sqlite3' -> '/release/sqlite3'
==============================
        not a dynamic executable
------------------------------
sqlite3: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, no section header
------------------------------
SQLite 3.47.0 2024-10-21 16:30:22 03a9703e27c44437c39363d0baf82db4ebc94538a0f28411c85dda156f82636e
gcc-13.2.1 20240309 (64-bit)
==============================
```

Build output:
```bash
build2:~/static-sqlite3$ ls -l ./release/sqlite3; ldd ./release/sqlite3
-rwxr-xr-x 1 root root 1028788 Nov 18 15:57 ./release/sqlite3
        not a dynamic executable
build2:~/static-sqlite3$ ./release/sqlite3 --version
3.47.0 2024-10-21 16:30:22 03a9703e27c44437c39363d0baf82db4ebc94538a0f28411c85dda156f82636e (64-bit)

```